### PR TITLE
Fix typo in task.json

### DIFF
--- a/nsis/task.json
+++ b/nsis/task.json
@@ -81,7 +81,7 @@
             "type": "filePath",
             "label": "Custom Plugins Path",
             "defaultValue": "",
-            "helpMarkDown": "If you want include additional plugins that aren't in our defualt directory, you could specify your plugin directory so your plugins will copied and used into NSIS process. This will work with plugins/x86-ansi",
+            "helpMarkDown": "If you want include additional plugins that aren't in our default directory, you could specify your plugin directory so your plugins will copied and used into NSIS process. This will work with plugins/x86-ansi",
             "required": "false"
         }
 


### PR DESCRIPTION
Fix a typo in the "helpMarkDown" for includeCustomPluginsPath.